### PR TITLE
`--force` is required to install firmware for the first time

### DIFF
--- a/views/FRE-install.jade
+++ b/views/FRE-install.jade
@@ -60,7 +60,7 @@ block content
       h3#firmware Update Tessel's Firmware
       p Plug Tessel into your computer via USB. In the command line, run
         code
-          cli tessel update
+          cli tessel update -f
       p The lights should blink yellow and red during the firmware upload.
       p Once the firmware update is complete, continue to the next step.
 


### PR DESCRIPTION
On my tessel board, `tessel update` failed because there's no firmware installed

``` bash
> tessel update
TESSEL! Connected to <SERIAL>.
INFO Checking for latest firmware...
ERR! No builds were found
```

Instead, we should add `--force` option for the first time to install the firmware

``` bash
> tessel update -f
TESSEL! Connected to <SERIAL>
INFO Checking for latest firmware...
INFO Downloading firmware from https://builds.tessel.io/firmware/tessel-firmware-current.bin
INFO Updating firmware... please wait. Tessel will reset itself after the update
Waiting for bootloader....
Writing: 100%  1186168 /1186168
Done! 
```
