### PR TITLE
Add license, update README, fix #25

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2014 Technical Machine, Inc
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-#Tessel's getting started page
+# Tessel's getting started page
 
-## Start
+Hosted at [start.tessel.io](http://start.tessel.io/)
 
-`node app.js`
+## Installation
+
+`npm install`
+
+## Usage
+
+`npm start`
+
+## License
+
+MIT

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "application-name",
+  "name": "start.tessel.io",
   "version": "0.0.1",
   "private": true,
   "scripts": {
@@ -7,8 +7,8 @@
   },
   "dependencies": {
     "express": "3.3",
-    "jade": "*",
-    "request": "*"
+    "jade": "1.3.1",
+    "request": "2.37.0"
   },
   "jshintConfig": {
     "node": true,

--- a/views/_FRE-sidebar.jade
+++ b/views/_FRE-sidebar.jade
@@ -20,6 +20,6 @@ div#fre-sidebar
     li( class=(page === "tweet" ? "active" : ""))
       a(href="/tweet") 5. tweet
     li( class=(page === "usage" ? "active" : ""))
-      a(href="/usage") 5. usage
+      a(href="/usage") 6. usage
     li( class=(page === "finished" ? "active" : ""))
-      a(href="/finished") 6. finished
+      a(href="/finished") 7. finished


### PR DESCRIPTION
- Add MIT License
- Update README on installation instructions and using `npm start` instead of `node app.js`
- Give exact versions for `jade` and `request`
- Name your `package.json` application
- Fix #25 numbering issue in site
