### PR TITLE
Fix problem with node_modules in home directory

### DIFF
--- a/views/FRE-blinky.jade
+++ b/views/FRE-blinky.jade
@@ -12,6 +12,7 @@ block content
           p In your command line, make a folder for your Tessel code, change directory into that folder, and then initialize <a href="https://www.npmjs.org/">npm</a> in that folder:
           code
             cli mkdir tessel-code
+            cli cd tessel-code
             cli npm init
           p You can press enter at each option within npm init to accept npm's defaults.
           p Great! Now you're set up to run code on Tessel.


### PR DESCRIPTION
I had someone at a workshop run npm init in their home directory. Even though they changed directory to `tessel-code` later, `npm install` will look a few directories up for a package.json file and put node_modules in there. This being the home directory, npm actually refuses to use ~/node_modules when running (but not install).
