### PR TITLE
Update Linux install directions for cli 0.3.20 (node-usb 1.0)

### DIFF
--- a/views/FRE-install.jade
+++ b/views/FRE-install.jade
@@ -41,7 +41,7 @@ block content
             cli apt-get install nodejs nodejs-legacy
           p Once Node is installed, run this in your terminal:
           code
-            cli apt-get install libusb-1.0-0-dev
+            cli apt-get install libusb-1.0-0-dev libudev-dev
             cli npm install -g tessel
           p If the installation didn't work, please post the error message to our <a href="http://forums.tessel.io/category/installation-issues">forums</a> and we'll help you out.</i>
           p If the scripts ran without errors, proceed to <a href="#firmware">update the firmware</a>.


### PR DESCRIPTION
node-usb now bundles its own copy of libusb. To build it, it needs
libudev-dev installed.